### PR TITLE
chore: add OIDC permissions and standardize job name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   release:
     name: 'Release'


### PR DESCRIPTION
Add OIDC permissions for npm trusted publishing and standardize job name to Release per boilerplate.